### PR TITLE
use col-md-* instead of col-lg-*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+[Upcoming changes][unreleased]
+
+## [v0.0.2]
+
+### Changed
+- default to using col-md-* instead of col-lg-*
+
+## [v0.0.1]
+
+Inital release
+
+[unreleased]: https://github.com/dbouwman/nester/compare/v0.0.2...HEAD
+[v0.0.2]: https://github.com/dbouwman/nester/compare/v0.0.1...v0.0.2
+[v0.0.1]: https://github.com/dbouwman/nester/commits/v0.0.1

--- a/dist/browser/nester.js
+++ b/dist/browser/nester.js
@@ -36,7 +36,7 @@ module.exports = api;
 //       }
 //       //copy the card
 //       col = JSON.parse(JSON.stringify(card));
-//       col.classNames = 'card-debug col-lg-' + col.width;
+//       col.classNames = 'card-debug col-md-' + col.width;
 //       //console.log(' column class: ', col.classNames);
 //       //if x is not the same as our current x, add an offset
 //       if(col.x !== current.x){
@@ -247,9 +247,9 @@ api.addClassesToCard = function(card, offset, nestingWidth){
     }else{
       width = Math.floor(width);
     }
-    console.log('**** NESTING WIDTH ' + nestingWidth + ' card width: ' + card.width + ' class: col-lg-' + width);
+    console.log('**** NESTING WIDTH ' + nestingWidth + ' card width: ' + card.width + ' class: col-md-' + width);
   }
-  card.classNames = 'card-debug col-lg-' + width;
+  card.classNames = 'card-debug col-md-' + width;
   card.minHeight = card.height * 60;
   if(offset){
     card.classNames = card.classNames + ' col-sm-offset-' + offset;

--- a/nester.js
+++ b/nester.js
@@ -35,7 +35,7 @@ module.exports = api;
 //       }
 //       //copy the card
 //       col = JSON.parse(JSON.stringify(card));
-//       col.classNames = 'card-debug col-lg-' + col.width;
+//       col.classNames = 'card-debug col-md-' + col.width;
 //       //console.log(' column class: ', col.classNames);
 //       //if x is not the same as our current x, add an offset
 //       if(col.x !== current.x){
@@ -246,9 +246,9 @@ api.addClassesToCard = function(card, offset, nestingWidth){
     }else{
       width = Math.floor(width);
     }
-    console.log('**** NESTING WIDTH ' + nestingWidth + ' card width: ' + card.width + ' class: col-lg-' + width);
+    console.log('**** NESTING WIDTH ' + nestingWidth + ' card width: ' + card.width + ' class: col-md-' + width);
   }
-  card.classNames = 'card-debug col-lg-' + width;
+  card.classNames = 'card-debug col-md-' + width;
   card.minHeight = card.height * 60;
   if(offset){
     card.classNames = card.classNames + ' col-sm-offset-' + offset;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nester",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Convert array of {x: N, y: N, height:N, width:N, component:{...}} into nested row object with classes for responsive bootstrap.",
   "main": "index.js",
   "dependencies": {

--- a/test/nester.spec.js
+++ b/test/nester.spec.js
@@ -23,9 +23,9 @@ describe('nester : ', function () {
       it('should have one row ', function () {
         expect(output.length).to.equal(1);
       });
-      it('row should have one col-lg-12', function () {
+      it('row should have one col-md-12', function () {
         expect(output[0].cols.length).to.equal(1);
-        expect(output[0].cols[0].classNames).to.contain('col-lg-12');
+        expect(output[0].cols[0].classNames).to.contain('col-md-12');
       });
     });
 
@@ -42,10 +42,10 @@ describe('nester : ', function () {
         expect(output.length).to.equal(1);
       });
 
-      it('should have two col-lg-6', function () {
+      it('should have two col-md-6', function () {
         expect(output[0].cols.length).to.equal(2);
-        expect(output[0].cols[0].classNames).to.contain('col-lg-6');
-        expect(output[0].cols[1].classNames).to.contain('col-lg-6');
+        expect(output[0].cols[0].classNames).to.contain('col-md-6');
+        expect(output[0].cols[1].classNames).to.contain('col-md-6');
       });
     });
 
@@ -67,11 +67,11 @@ describe('nester : ', function () {
       });
       it('first col: col-sm-offset 1, width:3', function () {
         expect(output[0].cols[0].classNames).to.contain('col-sm-offset-1');
-        expect(output[0].cols[0].classNames).to.contain('col-lg-3');
+        expect(output[0].cols[0].classNames).to.contain('col-md-3');
       });
       it('second col: col-sm-offset 1, width:3', function () {
         expect(output[0].cols[1].classNames).to.contain('col-sm-offset-2');
-        expect(output[0].cols[1].classNames).to.contain('col-lg-3');
+        expect(output[0].cols[1].classNames).to.contain('col-md-3');
       });
 
     });
@@ -94,11 +94,11 @@ describe('nester : ', function () {
       });
       it('first col: no offset width:3', function () {
         expect(output[0].cols[0].classNames).not.to.contain('col-sm-offset');
-        expect(output[0].cols[0].classNames).to.contain('col-lg-3');
+        expect(output[0].cols[0].classNames).to.contain('col-md-3');
       });
       it('second col: col-sm-offset 6, width:3', function () {
         expect(output[0].cols[1].classNames).to.contain('col-sm-offset-6');
-        expect(output[0].cols[1].classNames).to.contain('col-lg-3');
+        expect(output[0].cols[1].classNames).to.contain('col-md-3');
       });
     });
 
@@ -119,10 +119,10 @@ describe('nester : ', function () {
       it('should have two rows ', function () {
         expect(output.length).to.equal(2);
       });
-      it('rows should have one col-lg-12', function () {
+      it('rows should have one col-md-12', function () {
         output.forEach(function(row){
           expect(row.cols.length).to.equal(1);
-          expect(row.cols[0].classNames).to.contain('col-lg-12');
+          expect(row.cols[0].classNames).to.contain('col-md-12');
         });
       });
     });//one col per row
@@ -141,16 +141,16 @@ describe('nester : ', function () {
       it('should have two rows ', function () {
         expect(output.length).to.equal(2);
       });
-      it('row 1 has 3 col-lg-4', function () {
+      it('row 1 has 3 col-md-4', function () {
         expect(output[0].cols.length).to.equal(3);
         output[0].cols.forEach(function(col){
-          expect(col.classNames).to.contain('col-lg-4');
+          expect(col.classNames).to.contain('col-md-4');
         });
       });
-      it('row 2 has 2 col-lg-6', function () {
+      it('row 2 has 2 col-md-6', function () {
         expect(output[1].cols.length).to.equal(2);
         output[1].cols.forEach(function(col){
-          expect(col.classNames).to.contain('col-lg-6');
+          expect(col.classNames).to.contain('col-md-6');
         });
       });
 
@@ -168,15 +168,15 @@ describe('nester : ', function () {
       it('should have two rows ', function () {
         expect(output.length).to.equal(2);
       });
-      it('row 1 has 2 col-lg-4 with an offset', function () {
+      it('row 1 has 2 col-md-4 with an offset', function () {
         expect(output[0].cols.length).to.equal(2);
-        expect(output[0].cols[0].classNames).to.contain('col-lg-4');
-        expect(output[0].cols[1].classNames).to.contain('col-lg-4');
+        expect(output[0].cols[0].classNames).to.contain('col-md-4');
+        expect(output[0].cols[1].classNames).to.contain('col-md-4');
         expect(output[0].cols[1].classNames).to.contain('col-sm-offset-4');
       });
-      it('row 2 has offset and col-lg-6', function () {
+      it('row 2 has offset and col-md-6', function () {
         expect(output[1].cols.length).to.equal(1);
-        expect(output[1].cols[0].classNames).to.contain('col-lg-6');
+        expect(output[1].cols[0].classNames).to.contain('col-md-6');
         expect(output[1].cols[0].classNames).to.contain('col-sm-offset-6');
       });
 
@@ -208,13 +208,13 @@ describe('nester : ', function () {
       it('should have one row', function () {
         expect(output.length).to.equal(1);
       });
-      it('first col should be col-lg-6', function () {
+      it('first col should be col-md-6', function () {
         expect(output[0].cols[1].rows).not.to.be.defined;
-        expect(output[0].cols[1].classNames).to.contain('col-lg-6');
+        expect(output[0].cols[1].classNames).to.contain('col-md-6');
       });
-      it('second col should be col-lg-6 no offset', function () {
+      it('second col should be col-md-6 no offset', function () {
         var col = output[0].cols[1];
-        expect(col.classNames).to.contain('col-lg-6');
+        expect(col.classNames).to.contain('col-md-6');
         expect(col.classNames).not.to.contain('offset');
       });
       it('second col should have nested row with two entries', function () {
@@ -226,9 +226,9 @@ describe('nester : ', function () {
         var col = output[0].cols[1].rows[0].cols[0];
         expect(col.classNames).not.to.contain('offset');
       });
-      it('nested row, col 0, should be col-lg-12', function () {
+      it('nested row, col 0, should be col-md-12', function () {
         var col = output[0].cols[1].rows[0].cols[0];
-        expect(col.classNames).to.contain('col-lg-12');
+        expect(col.classNames).to.contain('col-md-12');
       });
 
     });
@@ -254,31 +254,31 @@ describe('nester : ', function () {
       it('should have one row', function () {
         expect(output.length).to.equal(1);
       });
-      it('first col should be col-lg-4', function () {
+      it('first col should be col-md-4', function () {
         var col = output[0].cols[0];
         expect(col.rows).not.to.be.defined;
-        expect(col.classNames).to.contain('col-lg-4');
+        expect(col.classNames).to.contain('col-md-4');
       });
-      it('second col should be col-lg-8 no offset', function () {
+      it('second col should be col-md-8 no offset', function () {
         var col = output[0].cols[1];
-        expect(col.classNames).to.contain('col-lg-8');
+        expect(col.classNames).to.contain('col-md-8');
         expect(col.classNames).not.to.contain('offset');
       });
-      it('nested row 0, col 0 should be col-lg-8', function () {
+      it('nested row 0, col 0 should be col-md-8', function () {
         var col = output[0].cols[1].rows[0].cols[0];
-        expect(col.classNames).to.contain('col-lg-8');
+        expect(col.classNames).to.contain('col-md-8');
       });
-      it('nested row 0, col 1 should be col-lg-4', function () {
+      it('nested row 0, col 1 should be col-md-4', function () {
         var col = output[0].cols[1].rows[0].cols[1];
-        expect(col.classNames).to.contain('col-lg-4');
+        expect(col.classNames).to.contain('col-md-4');
       });
-      it('nested row 1, col 0 should be col-lg-9', function () {
+      it('nested row 1, col 0 should be col-md-9', function () {
         var col = output[0].cols[1].rows[1].cols[0];
-        expect(col.classNames).to.contain('col-lg-9');
+        expect(col.classNames).to.contain('col-md-9');
       });
-      it('nested row 1, col 1 should be col-lg-3', function () {
+      it('nested row 1, col 1 should be col-md-3', function () {
         var col = output[0].cols[1].rows[1].cols[1];
-        expect(col.classNames).to.contain('col-lg-3');
+        expect(col.classNames).to.contain('col-md-3');
       });
 
 
@@ -304,14 +304,14 @@ describe('nester : ', function () {
       it('should have one row', function () {
         expect(output.length).to.equal(1);
       });
-      it('first col should be col-lg-4', function () {
+      it('first col should be col-md-4', function () {
         var col = output[0].cols[0];
         expect(col.rows).not.to.be.defined;
-        expect(col.classNames).to.contain('col-lg-4');
+        expect(col.classNames).to.contain('col-md-4');
       });
-      it('second col should be col-lg-8 no offset', function () {
+      it('second col should be col-md-8 no offset', function () {
         var col = output[0].cols[1];
-        expect(col.classNames).to.contain('col-lg-8');
+        expect(col.classNames).to.contain('col-md-8');
         expect(col.classNames).not.to.contain('offset');
       });
 
@@ -358,7 +358,7 @@ describe('nester : ', function () {
       });
       it('second row: first col should have classNames', function () {
         expect(output[1].cols[0].classNames).to.be.defined;
-        expect(output[1].cols[0].classNames).to.contain('col-lg-12');
+        expect(output[1].cols[0].classNames).to.contain('col-md-12');
       });
 
     });
@@ -563,10 +563,10 @@ describe('nester : ', function () {
           expect(output.length).to.equal(2);
         });
         it('first col should be a normal column', function () {
-          expect(output[0].classNames).to.contain('col-lg-6');
+          expect(output[0].classNames).to.contain('col-md-6');
         });
         it('second col should have classNames', function () {
-          expect(output[1].classNames).to.contain('col-lg-6');
+          expect(output[1].classNames).to.contain('col-md-6');
         });
         it('second col should have row array length 2', function () {
           expect(output[1].rows.length).to.equal(2);


### PR DESCRIPTION
Related to #1, tho doesn't resolve it. Default to `col-md-*` instead of `col-lg-*`. Does not allow for overrides.

I've tested this in OD admin app, and now columns are preserved down to 1024x768.

FYI I did _not_ bump version in package.json.

Also, this should make it so @apfister doesn't have to use his own fork.
